### PR TITLE
Allow to find Xamarin.Forms pages in different assembly

### DIFF
--- a/Cirrious.MvvmCross.Forms.Presenter.Core/Cirrious.MvvmCross.Forms.Presenter.Core.csproj
+++ b/Cirrious.MvvmCross.Forms.Presenter.Core/Cirrious.MvvmCross.Forms.Presenter.Core.csproj
@@ -36,6 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="IMvxFormsPageLoader.cs" />
+    <Compile Include="MvxFormsPageLoader.cs" />
     <Compile Include="MvxFormsPagePresenter.cs" />
     <Compile Include="MvxPresenterHelpers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Cirrious.MvvmCross.Forms.Presenter.Core/IMvxFormsPageLoader.cs
+++ b/Cirrious.MvvmCross.Forms.Presenter.Core/IMvxFormsPageLoader.cs
@@ -1,0 +1,10 @@
+using Cirrious.MvvmCross.ViewModels;
+using Xamarin.Forms;
+
+namespace Cirrious.MvvmCross.Forms.Presenter.Core
+{
+	public interface IMvxFormsPageLoader
+	{
+		Page LoadPage(MvxViewModelRequest request);
+	}
+}

--- a/Cirrious.MvvmCross.Forms.Presenter.Core/MvxFormsPageLoader.cs
+++ b/Cirrious.MvvmCross.Forms.Presenter.Core/MvxFormsPageLoader.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Cirrious.CrossCore;
+using Cirrious.CrossCore.IoC;
+using Cirrious.MvvmCross.ViewModels;
+using Xamarin.Forms;
+
+namespace Cirrious.MvvmCross.Forms.Presenter.Core
+{
+	public class MvxFormsPageLoader : IMvxFormsPageLoader
+	{
+		private MvxViewModelRequest _request;
+
+		public Page LoadPage(MvxViewModelRequest request)
+		{
+			_request = request;
+
+			var pageName = GetPageName();
+			var pageType = GetPageType(pageName);
+
+			if (pageType == null)
+			{
+				Mvx.Trace("Page not found for {0}", pageName);
+				return null;
+			}
+
+			var page = Activator.CreateInstance(pageType) as Page;
+			if (page == null)
+			{
+				Mvx.Error("Failed to create ContentPage {0}", pageName);
+			}
+			return page;
+		}
+
+		protected virtual string GetPageName()
+		{
+			var viewModelName = _request.ViewModelType.Name;
+			return viewModelName.Replace("ViewModel", "Page");
+		}
+
+		protected virtual Type GetPageType(string pageName)
+		{
+			return _request.ViewModelType.GetTypeInfo().Assembly.CreatableTypes()
+				.FirstOrDefault(t => t.Name == pageName);
+		}
+	}
+}

--- a/Cirrious.MvvmCross.Forms.Presenter.Core/MvxPresenterHelpers.cs
+++ b/Cirrious.MvvmCross.Forms.Presenter.Core/MvxPresenterHelpers.cs
@@ -6,43 +6,33 @@
 // Project Lead - Tomasz Cielecki, @cheesebaron, mvxplugins@ostebaronen.dk
 // Contributor - Marcos Cobeña Morián, @CobenaMarcos, marcoscm@me.com
 ﻿
-﻿using System;
-using System.Linq;
-using System.Reflection;
-using Cirrious.CrossCore;
-using Cirrious.CrossCore.IoC;
+﻿using Cirrious.CrossCore;
 using Cirrious.MvvmCross.ViewModels;
 using Xamarin.Forms;
 
 namespace Cirrious.MvvmCross.Forms.Presenter.Core
 {
-    public static class MvxPresenterHelpers
-    {
-        public static IMvxViewModel LoadViewModel(MvxViewModelRequest request)
-        {
-            var viewModelLoader = Mvx.Resolve<IMvxViewModelLoader>();
-            var viewModel = viewModelLoader.LoadViewModel(request, null);
-            return viewModel;
-        }
+	public static class MvxPresenterHelpers
+	{
+		public static IMvxViewModel LoadViewModel(MvxViewModelRequest request)
+		{
+			var viewModelLoader = Mvx.Resolve<IMvxViewModelLoader>();
+			var viewModel = viewModelLoader.LoadViewModel(request, null);
+			return viewModel;
+		}
 
-        public static Page CreatePage(MvxViewModelRequest request)
-        {
-            var viewModelName = request.ViewModelType.Name;
-            var pageName = viewModelName.Replace("ViewModel", "Page");
-            var pageType = request.ViewModelType.GetTypeInfo().Assembly.CreatableTypes()
-                                  .FirstOrDefault(t => t.Name == pageName);
-            if (pageType == null)
-            {
-                Mvx.Trace("Page not found for {0}", pageName);
-                return null;
-            }
-
-            var page = Activator.CreateInstance(pageType) as Page;
-            if (page == null)
-            {
-                Mvx.Error("Failed to create ContentPage {0}", pageName);
-            }
-            return page;
-        }
-    }
+		public static Page CreatePage(MvxViewModelRequest request)
+		{
+			IMvxFormsPageLoader viewPageLoader;
+			Mvx.TryResolve(out viewPageLoader);
+			if (viewPageLoader == null)
+			{
+				// load default instead
+				viewPageLoader = new MvxFormsPageLoader();
+				Mvx.RegisterSingleton(viewPageLoader);
+			}
+			var page = viewPageLoader.LoadPage(request);
+			return page;
+		}
+	}
 }


### PR DESCRIPTION
This change allows that ViewModels and Pages are not in the same assembly. Original code was looking for Pages in the same assembly as the requested ViewModel.

The standard behavior has not changed from the Original code; however it is now possible to implement your own `MvxFormsPageLoader` instance with your own logic to "find" the page. You then have to register the `IMvxFormsPageLoader` into your IOC container.

Example. I have an assembly with the ViewModels (no reference to Xamarin.Forms); another assembly that contains the Pages (references Xamarin.Forms). In the Xamarin.Forms assembly I created a custom PageLoader.

```
	public class MyFormsPageLoader : MvxFormsPageLoader
	{
		protected override Type GetPageType(string pageName)
		{
			var types = GetType().GetTypeInfo().Assembly.CreatableTypes();
			var pageType = types.FirstOrDefault(t => t.Name == pageName);
			return pageType;
		}
	}
```

In order to get this page loader inside the IOC container I have to add following code in each platforms Setup.cs:

```
		protected override void InitializeViewLookup()
		{
			base.InitializeViewLookup();
			Mvx.RegisterSingleton<IMvxFormsPageLoader>(new MyFormsPageLoader());
		}
```

Of course, the above can be accomplished in the Initialization of the App.cs, but in my case the App.cs has no reference towards Xamarin.Forms (only viewmodels are there).

Comments welcome!

