### PR TITLE
Fixes for #45

### DIFF
--- a/MvvmCross.Forms.Presenter.Core/MvxFormsPageLoader.cs
+++ b/MvvmCross.Forms.Presenter.Core/MvxFormsPageLoader.cs
@@ -5,19 +5,18 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Xamarin.Forms;
+using MvvmCross.Core.Views;
 
 namespace MvvmCross.Forms.Presenter.Core
 {
     public class MvxFormsPageLoader : IMvxFormsPageLoader
     {
-        private MvxViewModelRequest _request;
+		private IMvxViewsContainer _viewFinder;
 
         public Page LoadPage(MvxViewModelRequest request)
         {
-            _request = request;
-
-            var pageName = GetPageName();
-            var pageType = GetPageType(pageName);
+			var pageName = GetPageName(request);
+			var pageType = GetPageType(request);
 
             if (pageType == null)
             {
@@ -33,16 +32,18 @@ namespace MvvmCross.Forms.Presenter.Core
             return page;
         }
 
-        protected virtual string GetPageName()
+		protected virtual string GetPageName(MvxViewModelRequest request)
         {
-            var viewModelName = _request.ViewModelType.Name;
+            var viewModelName = request.ViewModelType.Name;
             return viewModelName.Replace("ViewModel", "Page");
         }
 
-        protected virtual Type GetPageType(string pageName)
+		protected virtual Type GetPageType(MvxViewModelRequest request)
         {
-            return _request.ViewModelType.GetTypeInfo().Assembly.CreatableTypes()
-                .FirstOrDefault(t => t.Name == pageName);
+			if (_viewFinder == null)
+				_viewFinder = Mvx.Resolve<IMvxViewsContainer> ();
+
+			return _viewFinder.GetViewType (request.ViewModelType);
         }
     }
 }

--- a/MvvmCross.Forms.Presenter.Core/MvxFormsPagePresenter.cs
+++ b/MvvmCross.Forms.Presenter.Core/MvxFormsPagePresenter.cs
@@ -62,14 +62,11 @@ namespace MvvmCross.Forms.Presenter.Core
             }
         }
 
-        public void AddPresentationHintHandler<THint>(Func<THint, bool> action)
-            where THint : MvxPresentationHint
+        public override void Show(MvxViewModelRequest request)
         {
-        }
-
-        public override async void Show(MvxViewModelRequest request)
-        {
-            if (await TryShowPage(request))
+			// async void is a nono, calling this sync because weirdness on startup as 
+			// Show method is not awaited itself hence code continues without blocking.
+			if (TryShowPage(request).GetAwaiter().GetResult())
                 return;
 
             Mvx.Error("Skipping request for {0}", request.ViewModelType.Name);


### PR DESCRIPTION
This PR fixes where the Forms presenter finds its Pages. It was looking at the Assembly where the ViewModel's were in before, which was incorrect. Now it uses IMvxViewsContainer which allows the dev to override how they are found by either overriding `GetViewsAssemblies` or `InitializeViewLookup`.

This PR also fixes issues with the Show method in the Forms presenter. Show method is not awaited by MvvmCross. It was marked async void before, so code continued to run even though someone would expect it not to. This means there were issues with AppDelegate on iOS where FinishedLaunching expects something to be presented at the end of it. However, in some cases this would not happen because the async method had not yet finished finding a page etc.